### PR TITLE
Design/#72 feat mobile menu size

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -36,7 +36,7 @@ export default async function LocaleLayout({
           <NextIntlClientProvider messages={messages}>
             <ReactQueryProvider>
               <Header />
-              <main className="web:max-w-web web:px-0 tablet:px-tablet-padding px-mobile-padding flex w-full flex-1 justify-center self-center overflow-auto">
+              <main className="tablet:mt-15 web:max-w-web web:px-0 tablet:px-tablet-padding px-mobile-padding mt-14 flex w-full flex-1 justify-center self-center overflow-auto">
                 {children}
               </main>
               <ToastProvider />

--- a/src/widgets/Header/ui/Header.tsx
+++ b/src/widgets/Header/ui/Header.tsx
@@ -14,7 +14,7 @@ export const Header = () => {
   const locale = pathname.startsWith('/en') ? 'en' : 'ko';
 
   return (
-    <header className="tablet:h-15 px-mobile-padding tablet:px-tablet-padding relative flex h-14 justify-center gap-5 border-b border-gray-200 bg-white">
+    <header className="tablet:h-15 px-mobile-padding tablet:px-tablet-padding fixed z-[var(--z-sticky)] flex h-14 w-full justify-center gap-5 border-b border-gray-200 bg-white">
       <div className="web:max-w-web flex w-full items-center justify-between">
         <div className="flex items-center gap-5">
           <MobileGNB />

--- a/src/widgets/Header/ui/MobileGNB.tsx
+++ b/src/widgets/Header/ui/MobileGNB.tsx
@@ -52,7 +52,7 @@ export const MobileGNB = () => {
       {/* 드로워 */}
       <nav
         className={clsx(
-          'fixed top-0 left-0 z-[var(--z-drawer)] h-full w-64 bg-white shadow transition-transform duration-300',
+          'fixed top-0 left-0 z-[var(--z-drawer)] h-full w-50 bg-white shadow transition-transform duration-300',
           open ? 'translate-x-0' : '-translate-x-full',
         )}
       >

--- a/src/widgets/Header/ui/MobileGNB.tsx
+++ b/src/widgets/Header/ui/MobileGNB.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
+import { usePathname } from 'next/navigation';
 import { ROUTES } from '@/shared/config/routes';
 import { Icon, XIcon } from '@/shared/ui/icon';
 import clsx from 'clsx';
@@ -10,6 +11,7 @@ import { HeaderLink } from './HeaderLink';
 export const MobileGNB = () => {
   const [open, setOpen] = useState(false);
   const t = useTranslations('navigation');
+  const pathname = usePathname();
 
   useEffect(() => {
     const handleResize = () => {
@@ -24,6 +26,10 @@ export const MobileGNB = () => {
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, []);
+
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname]);
 
   return (
     <>


### PR DESCRIPTION
#72

Closes #72

## 📢 변경 사항

- 모바일 메뉴 사이즈 줄임
- 이동시 메뉴 닫기 
- 헤더 상단 고정으로 스타일변경


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 메인 콘텐츠 컨테이너 상단에 여백이 추가되어 레이아웃의 세로 간격이 조정되었습니다.
  * 헤더가 고정(fixed) 위치로 변경되고 전체 너비로 확장되어 항상 화면 상단에 표시됩니다.
  * 모바일 내비게이션 드로어의 너비가 줄어들어 더 컴팩트하게 표시됩니다.

* **버그 수정**
  * 모바일 내비게이션 드로어가 페이지 이동 시 자동으로 닫히도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->