### PR TITLE
Feat/#99 상세페이지 찜 기능 연결 

### DIFF
--- a/src/entities/favorites/lib/favorite.ts
+++ b/src/entities/favorites/lib/favorite.ts
@@ -11,7 +11,7 @@ interface FetchFavoritesDataProps {
 const LIMIT = 10;
 export const fetchFavoritesData = async ({ ids, type, pageParam = 0 }: FetchFavoritesDataProps) => {
   if (ids.length === 0) {
-    return { items: [], nextOffset: undefined }; // 빈 배열과 다음 페이지 없음을 반환
+    return { items: [], nextOffset: undefined };
   }
 
   try {
@@ -32,6 +32,6 @@ export const fetchFavoritesData = async ({ ids, type, pageParam = 0 }: FetchFavo
     };
   } catch (error) {
     console.error('fetchFavoritesData error:', error);
-    return { items: [], nextOffset: undefined }; // 실패 시 빈 목록으로 fallback
+    return { items: [], nextOffset: undefined };
   }
 };

--- a/src/entities/gathering-detail/ui/GatheringDetailLayout.tsx
+++ b/src/entities/gathering-detail/ui/GatheringDetailLayout.tsx
@@ -103,6 +103,7 @@ export const GatheringDetailLayout = ({ id }: { id: number }) => {
         </div>
         {/* ContainerInformation 컴포넌트 */}
         <ContainerInformation
+          id={id}
           title={gathering.name || '제목 없음'}
           location={gathering.location}
           date={formattedDate}

--- a/src/features/favorites/model/usefavorites.ts
+++ b/src/features/favorites/model/usefavorites.ts
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { isFavorite, toggleFavorite } from './favoritesStorage';
+
+export const useFavoritesAction = (id: number) => {
+  const [isLiked, setIsLiked] = useState(false);
+
+  useEffect(() => {
+    setIsLiked(isFavorite(id));
+  }, [id]);
+
+  const handleFavoritesStorage = () => {
+    toggleFavorite(id);
+    setIsLiked(!isLiked);
+  };
+
+  return {
+    isLiked,
+    handleFavoritesStorage,
+  };
+};

--- a/src/features/favorites/model/usefavorites.ts
+++ b/src/features/favorites/model/usefavorites.ts
@@ -3,14 +3,17 @@
 import { useEffect, useState } from 'react';
 import { isFavorite, toggleFavorite } from './favoritesStorage';
 
-export const useFavoritesAction = (id: number) => {
+export const useFavoritesAction = (id?: number) => {
   const [isLiked, setIsLiked] = useState(false);
 
   useEffect(() => {
-    setIsLiked(isFavorite(id));
+    if (id !== undefined) {
+      setIsLiked(isFavorite(id));
+    }
   }, [id]);
 
   const handleFavoritesStorage = () => {
+    if (id === undefined) return;
     toggleFavorite(id);
     setIsLiked(!isLiked);
   };

--- a/src/features/gathering/ui/GatheringLikeButton.tsx
+++ b/src/features/gathering/ui/GatheringLikeButton.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { isFavorite, toggleFavorite } from '@/features/favorites/model/favoritesStorage';
+import { useFavoritesAction } from '@/features/favorites/model/usefavorites';
 import { LikeIcon, UnlikeIcon } from '@/shared/ui/icon';
 
 interface GatheringLikeButtonProps {
@@ -10,21 +9,10 @@ interface GatheringLikeButtonProps {
 }
 
 export const GatheringLikeButton = ({ gatheringId, onToggle }: GatheringLikeButtonProps) => {
-  const [isLiked, setIsLiked] = useState(false);
-
-  // localstorage에서 찜한 목록 가져오기
-  // gatheringId 있으면 isLiked true
-  // 없으면 isLiked false
-
-  useEffect(() => {
-    setIsLiked(isFavorite(gatheringId));
-  }, [gatheringId]);
+  const { isLiked, handleFavoritesStorage } = useFavoritesAction(gatheringId);
 
   const handleLike = () => {
-    // localstorage 찜 혹은 찜 해제
-    toggleFavorite(gatheringId);
-    setIsLiked(!isLiked);
-
+    handleFavoritesStorage();
     onToggle?.();
   };
 

--- a/src/widgets/ContainerInformation/ContainerInformation.test.tsx
+++ b/src/widgets/ContainerInformation/ContainerInformation.test.tsx
@@ -56,6 +56,7 @@ describe('ContainerInformation', () => {
   it('좋아요 버튼 클릭 시 아이콘 상태가 토글된다', () => {
     render(
       <ContainerInformation
+        id={1}
         title="테스트 모임"
         location="서울 강남"
         date="1월 7일"

--- a/src/widgets/ContainerInformation/ContainerInformation.tsx
+++ b/src/widgets/ContainerInformation/ContainerInformation.tsx
@@ -8,7 +8,7 @@ import { type VariantProps, cva } from 'class-variance-authority';
 import { AvatarGroup } from './AvatarGroup';
 
 type ContainerInformationProps = {
-  id: number;
+  id?: number;
   title: string;
   location: string;
   date: string; // e.g. '1월 7일'
@@ -45,10 +45,10 @@ export const ContainerInformation = ({
   id,
 }: ContainerInformationProps) => {
   const { isLiked, handleFavoritesStorage } = useFavoritesAction(id);
-  // const [isLiked, setIsLiked] = useState(false);
   const isConfirmed = participants.length >= minParticipants;
   const visibleAvatars = participants.slice(0, 4).map((p) => p.image);
   const extraCount = participants.length > 4 ? participants.length - 4 : 0;
+  console.log(isLiked, ' 좋냐!');
 
   return (
     <div className={containerInformationVariants({ size })}>

--- a/src/widgets/ContainerInformation/ContainerInformation.tsx
+++ b/src/widgets/ContainerInformation/ContainerInformation.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useFavoritesAction } from '@/features/favorites/model/usefavorites';
 import { InfoChip, StateChip } from '@/shared/ui/chip';
 import { LikeIcon, UnlikeIcon } from '@/shared/ui/icon';
 import { ProgressBar } from '@/shared/ui/progressbar';
@@ -8,6 +8,7 @@ import { type VariantProps, cva } from 'class-variance-authority';
 import { AvatarGroup } from './AvatarGroup';
 
 type ContainerInformationProps = {
+  id: number;
   title: string;
   location: string;
   date: string; // e.g. '1월 7일'
@@ -41,8 +42,10 @@ export const ContainerInformation = ({
   maxParticipants,
   minParticipants,
   size,
+  id,
 }: ContainerInformationProps) => {
-  const [isLiked, setIsLiked] = useState(false);
+  const { isLiked, handleFavoritesStorage } = useFavoritesAction(id);
+  // const [isLiked, setIsLiked] = useState(false);
   const isConfirmed = participants.length >= minParticipants;
   const visibleAvatars = participants.slice(0, 4).map((p) => p.image);
   const extraCount = participants.length > 4 ? participants.length - 4 : 0;
@@ -66,7 +69,7 @@ export const ContainerInformation = ({
         {/* 우측 상단 좋아요 */}
         <div className="flex">
           <button
-            onClick={() => setIsLiked((prev) => !prev)}
+            onClick={handleFavoritesStorage}
             className="cursor-pointer"
             aria-label={isLiked ? '좋아요 취소' : '좋아요'}
           >


### PR DESCRIPTION
# 관련 이슈

Closes #이슈번호

## 📢 변경 사항

- 찜 기능 커스텀 훅 분리, 
- 상세페이지 , 모임카드 부분 커스텀 훅으로 변경 

## 💬 그 외

- 상세페이지에 커스텀 훅 연결함에 따른, 
- 상세페이지 코드 변경 및, ContainerInformation 태스트코드 아주 살작 변경 되었습니다. 

## 📷 스크린샷 (선택)

## ❓ 질문 사항

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 즐겨찾기 상태를 관리하는 커스텀 훅(`useFavoritesAction`)이 추가되었습니다.

* **Refactor**
  * `ContainerInformation` 및 `GatheringLikeButton` 컴포넌트가 즐겨찾기 상태 관리를 커스텀 훅으로 대체하여 코드가 개선되었습니다.
  * `ContainerInformation` 컴포넌트에 선택적 `id` prop이 추가되었습니다.
  * `GatheringDetailLayout`에서 `ContainerInformation`에 `id` prop을 전달하도록 변경되었습니다.

* **Tests**
  * 테스트에서 `ContainerInformation` 컴포넌트에 `id` prop이 추가되었습니다.

* **Style**
  * 내부 주석이 제거되어 코드가 간결해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->