### PR TITLE
fix: (Signin)회원가입후 로그인시 경로 수정

### DIFF
--- a/src/features/signin/ui/SigninForm.tsx
+++ b/src/features/signin/ui/SigninForm.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { signIn } from 'next-auth/react';
-import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/navigation';
 import { ROUTES } from '@/shared/config/routes';
 import { AuthForm } from '@/widgets/AuthForm/ui/AuthForm';
@@ -23,32 +22,22 @@ export const SigninForm = () => {
     mode: 'onChange',
   });
 
-  const t = useTranslations();
-
   const onSubmit = async (formData: SigninFormData) => {
     const result = await signIn('credentials', {
       ...formData,
       redirect: false,
     });
+
     if (result?.error) {
       // 에러 처리
-      setError('email', { type: 'manual', message: t('errors.validation.cannotSignIn') });
+      setError('email', { type: 'manual', message: 'errors.validation.cannotSignIn' });
       return;
     }
 
-    if (process.env.NODE_ENV === 'development') {
-      console.log('LOGIN', { result });
-      console.log('[REFERRER]', document.referrer);
-    }
-
-    if (
-      !document.referrer ||
-      document.referrer.includes(ROUTES.SIGNIN) ||
-      document.referrer.includes(ROUTES.SIGNUP)
-    ) {
-      router.push(ROUTES.ROOT);
-    } else {
+    if (document.referrer.includes(ROUTES.GATHERING)) {
       router.push(document.referrer);
+    } else {
+      router.push(ROUTES.ROOT);
     }
   };
 


### PR DESCRIPTION
#120 

Closes #120 

## 📢 변경 사항

- 회원가입후 로그인시 경로 수정

## 💬 그 외

- 번역 함수 중복 제거 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 로그인 실패 시 표시되는 오류 메시지가 번역된 문구 대신 기본 문자열로 변경되었습니다.
  * 디버그 로그가 제거되어 개발 환경에서 로그인 결과와 리퍼러 정보가 더 이상 출력되지 않습니다.

* **리팩터링**
  * 로그인 후 리디렉션 로직이 간소화되어, 특정 경로가 포함된 경우에만 해당 경로로 이동하고 그 외에는 메인 페이지로 이동합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->