### PR TITLE
Test/getAuthImageSize,  Storybook/ProfileImage 

### DIFF
--- a/src/shared/lib/getAuthImageSize.test.ts
+++ b/src/shared/lib/getAuthImageSize.test.ts
@@ -1,0 +1,46 @@
+import { IMAGE_SIZE_BY_BREAKPOINTS, getAuthImageSize } from './getAuthImageSize';
+
+// getBreakpointsPx 모킹
+jest.mock('./getBreakpointsPx', () => ({
+  getBreakpointsPx: jest.fn().mockReturnValue({
+    mobile: 375, // 실제 CSS 변수 값과 일치시킴
+    tablet: 744, // --breakpoint-tablet: 46.5rem (46.5 * 16 = 744px)
+    web: 1200, // --breakpoint-web: 75rem (75 * 16 = 1200px)
+    desktop: 1920, // --breakpoint-desktop: 120rem (120 * 16 = 1920px)
+  }),
+}));
+
+describe('getAuthImageSize', () => {
+  it('모바일 화면(744px 미만)에서는 290을 반환해야 함', () => {
+    expect(getAuthImageSize(375)).toBe(IMAGE_SIZE_BY_BREAKPOINTS.mobile); // 아이폰 XR
+    expect(getAuthImageSize(743)).toBe(IMAGE_SIZE_BY_BREAKPOINTS.mobile); // 태블릿 직전
+  });
+
+  it('태블릿 화면(744px 이상 1200px 미만)에서는 407을 반환해야 함', () => {
+    expect(getAuthImageSize(744)).toBe(IMAGE_SIZE_BY_BREAKPOINTS.tablet); // 태블릿 시작
+    expect(getAuthImageSize(1024)).toBe(IMAGE_SIZE_BY_BREAKPOINTS.tablet); // 아이패드
+    expect(getAuthImageSize(1199)).toBe(IMAGE_SIZE_BY_BREAKPOINTS.tablet); // 웹 직전
+  });
+
+  it('웹 화면(1200px 이상)에서는 588을 반환해야 함', () => {
+    expect(getAuthImageSize(1200)).toBe(IMAGE_SIZE_BY_BREAKPOINTS.web); // 웹 시작
+    expect(getAuthImageSize(1440)).toBe(IMAGE_SIZE_BY_BREAKPOINTS.web); // 일반적인 웹
+    expect(getAuthImageSize(1920)).toBe(IMAGE_SIZE_BY_BREAKPOINTS.web); // 큰 모니터
+  });
+
+  it('경계값 테스트: 743px은 모바일 사이즈를 반환해야 함', () => {
+    expect(getAuthImageSize(743)).toBe(IMAGE_SIZE_BY_BREAKPOINTS.mobile);
+  });
+
+  it('경계값 테스트: 744px은 태블릿 사이즈를 반환해야 함', () => {
+    expect(getAuthImageSize(744)).toBe(IMAGE_SIZE_BY_BREAKPOINTS.tablet);
+  });
+
+  it('경계값 테스트: 1199px은 태블릿 사이즈를 반환해야 함', () => {
+    expect(getAuthImageSize(1199)).toBe(IMAGE_SIZE_BY_BREAKPOINTS.tablet);
+  });
+
+  it('경계값 테스트: 1200px은 웹 사이즈를 반환해야 함', () => {
+    expect(getAuthImageSize(1200)).toBe(IMAGE_SIZE_BY_BREAKPOINTS.web);
+  });
+});

--- a/src/shared/lib/getAuthImageSize.ts
+++ b/src/shared/lib/getAuthImageSize.ts
@@ -1,6 +1,6 @@
 import { getBreakpointsPx } from '@/shared/lib/getBreakpointsPx';
 
-const IMAGE_SIZE_BY_BREAKPOINTS = {
+export const IMAGE_SIZE_BY_BREAKPOINTS = {
   mobile: 290,
   tablet: 407,
   web: 588,

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -5,3 +5,5 @@ export {
   generateReviewsMetadata,
   generateGatheringDetailMetadata,
 } from './metadata';
+export { getBreakpointsPx } from './getBreakpointsPx';
+export { getAuthImageSize } from './getAuthImageSize';

--- a/src/shared/ui/ProfileImage/ProfileImage.stories.tsx
+++ b/src/shared/ui/ProfileImage/ProfileImage.stories.tsx
@@ -1,0 +1,108 @@
+import { ChangeEvent, useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { ProfileImage } from './ProfileImage';
+
+// 파일을 data URL로 변환하는 유틸리티 함수
+const toBase64 = (file: File): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = (error) => reject(error);
+  });
+
+const meta = {
+  title: 'shared/ProfileImage',
+  component: ProfileImage,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: {
+        type: 'number',
+        min: 20,
+        max: 200,
+        step: 10,
+      },
+      description: '프로필 이미지 크기 (px 단위)',
+    },
+    url: {
+      control: 'text',
+      description: '프로필 이미지 URL',
+    },
+    className: {
+      control: 'text',
+      description: '추가 CSS 클래스',
+    },
+  },
+} satisfies Meta<typeof ProfileImage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    size: 40,
+  },
+};
+
+export const WithCustomSize: Story = {
+  args: {
+    size: 80,
+  },
+};
+
+export const WithImage: Story = {
+  args: {
+    size: 56,
+    url: 'https://i.namu.wiki/i/bCmE_8XrnEYeEKlbme2ZS8rsG6dcB1vGD-UJtxvGncvXuYL9fiBqL8Fk_6cQ58EKJYTyyw9mA0LWK3yIaRYQow.webp',
+  },
+};
+
+export const WithFileUpload: Story = {
+  render: function Render(args) {
+    const [imageUrl, setImageUrl] = useState<string | undefined>(undefined);
+
+    const handleFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (file) {
+        try {
+          const url = await toBase64(file);
+          setImageUrl(url);
+        } catch (error) {
+          console.error('Error reading file:', error);
+        }
+      }
+    };
+
+    return (
+      <div className="flex flex-col items-center gap-4">
+        <div className="bg-primary px-4 py-2">
+          <ProfileImage
+            {...args}
+            url={imageUrl}
+          />
+        </div>
+        <div className="mt-4">
+          <label className="cursor-pointer rounded-md bg-blue-500 px-4 py-2 text-white transition-colors hover:bg-blue-600">
+            이미지 업로드
+            <input
+              type="file"
+              accept="image/*"
+              onChange={handleFileChange}
+              className="hidden"
+            />
+          </label>
+        </div>
+      </div>
+    );
+  },
+  args: {
+    size: 56,
+  },
+  parameters: {
+    controls: { exclude: ['url'] },
+  },
+};

--- a/src/shared/ui/ProfileImage/ProfileImage.test.tsx
+++ b/src/shared/ui/ProfileImage/ProfileImage.test.tsx
@@ -1,0 +1,78 @@
+import { JSX } from 'react';
+import { render, screen } from '@testing-library/react';
+import { ProfileImage } from './ProfileImage';
+
+// next/image 모킹
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: JSX.IntrinsicElements['img']) => {
+    const { src, ...rest } = props;
+    return (
+      <img
+        data-testid="profile-image"
+        src={src}
+        {...rest}
+      />
+    );
+  },
+}));
+
+describe('ProfileImage 컴포넌트', () => {
+  it('URL이 제공되지 않았을 때 기본 크기와 폴백 아이콘을 렌더링해야 함', () => {
+    const { container } = render(<ProfileImage />);
+
+    // 컨테이너가 올바른 기본 크기(40 + 6 테두리)를 가지는지 확인
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper).toHaveStyle({ width: '46px', height: '46px' });
+
+    // 폴백 아이콘이 렌더링되는지 확인
+
+    expect(screen.getByTestId('profile-icon')).toBeInTheDocument();
+  });
+
+  it('사용자 정의 크기로 렌더링해야 함', () => {
+    const customSize = 60;
+    const { container } = render(<ProfileImage size={customSize} />);
+
+    // 컨테이너가 올바른 사용자 정의 크기(60 + 6 테두리)를 가지는지 확인
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper).toHaveStyle({
+      width: `${customSize + 6}px`,
+      height: `${customSize + 6}px`,
+    });
+  });
+
+  it('URL이 제공되었을 때 이미지를 렌더링해야 함', () => {
+    const testUrl = 'https://example.com/user.png';
+    render(<ProfileImage url={testUrl} />);
+
+    // 이미지가 올바른 URL과 기본 alt 텍스트로 렌더링되는지 확인
+    const image = screen.getByTestId('profile-image');
+    expect(image).toHaveAttribute('src', testUrl);
+    expect(image).toHaveAttribute('alt', 'user profile image'); // 컴포넌트에서 하드코딩된 값
+    expect(image).toHaveClass('object-cover');
+  });
+
+  it('사용자 정의 클래스명을 적용해야 함', () => {
+    const customClass = 'custom-class';
+    const { container } = render(<ProfileImage className={customClass} />);
+
+    // 컨테이너에 사용자 정의 클래스가 적용되었는지 확인
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper).toHaveClass(customClass);
+  });
+
+  it('적절한 스타일 클래스를 가지고 있어야 함', () => {
+    const { container } = render(<ProfileImage />);
+
+    // 컨테이너가 올바른 기본 클래스들을 가지고 있는지 확인
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper).toHaveClass(
+      'relative',
+      'overflow-hidden',
+      'rounded-full',
+      'border-3',
+      'border-white',
+    );
+  });
+});

--- a/src/shared/ui/ProfileImage/ProfileImage.tsx
+++ b/src/shared/ui/ProfileImage/ProfileImage.tsx
@@ -6,7 +6,6 @@ interface ProfileImageProps {
   size?: number; // 정사각형 한 변의 길이 (px)
   url?: string; // 프로필 이미지 URL
   className?: string; // 추가 커스텀 클래스
-  alt?: string; // img alt
 }
 
 export const ProfileImage = ({ size = 40, url, className }: ProfileImageProps) => {
@@ -18,13 +17,16 @@ export const ProfileImage = ({ size = 40, url, className }: ProfileImageProps) =
       {url ? (
         <Image
           src={url}
-          alt={'alt'}
+          alt={'user profile image'}
           fill
           sizes={`${size}px`}
           className="object-cover"
         />
       ) : (
-        <ProfileIcon size={size} />
+        <ProfileIcon
+          size={size}
+          data-testid="profile-icon"
+        />
       )}
     </div>
   );


### PR DESCRIPTION


## 📢 변경 사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * ProfileImage 컴포넌트의 다양한 사용 예시를 보여주는 Storybook 스토리가 추가되었습니다. 파일 업로드를 통한 이미지 미리보기 기능도 포함되어 있습니다.

* **버그 수정**
  * ProfileImage 컴포넌트의 alt 속성이 'user profile image'로 더 명확하게 변경되었습니다.

* **테스트**
  * getAuthImageSize 함수와 ProfileImage 컴포넌트에 대한 테스트가 추가되어 동작이 검증되었습니다.

* **문서화**
  * ProfileImage 컴포넌트의 Storybook 문서가 추가되었습니다.

* **리팩터**
  * ProfileImageProps에서 alt 속성이 제거되었습니다.
  * 일부 상수가 외부에서 사용할 수 있도록 공개되었습니다.
  * 라이브러리 내 주요 함수들이 중앙 export 파일에 추가되어 접근성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->